### PR TITLE
feat: add obstacle categories and sidewalk-aware weights

### DIFF
--- a/scripts/generate_dataset.py
+++ b/scripts/generate_dataset.py
@@ -1,11 +1,14 @@
 """Synthetic dataset generation for NN Motion demo.
 
-This script creates random driving scenes with static obstacles.  Obstacles
-whose longitudinal distance exceeds ``speed * 7`` are assigned zero cost
-weight, allowing the outer network to ignore far-away objects.
+This script creates random driving scenes with static obstacles and basic
+roadside context.  Each obstacle is assigned a category (e.g. vehicle,
+pedestrian) and a corresponding cost weight.  Pedestrians close to a generated
+sidewalk receive larger weights so that the learning algorithm can emphasise
+their avoidance.  Obstacles whose longitudinal distance exceeds ``speed * 7``
+are given zero weight, allowing the outer network to ignore far-away objects.
 
 The scenes are generated in parallel using the ``multiprocessing`` module and
-both JSON data and corresponding matplotlib visualizations are written to the
+both JSON data and corresponding matplotlib visualisations are written to the
 ``data/`` directory.
 """
 
@@ -24,6 +27,7 @@ import matplotlib.pyplot as plt
 
 @dataclass
 class Obstacle:
+    category: str
     distance: float
     lateral: float
     weight: float
@@ -32,37 +36,68 @@ class Obstacle:
 @dataclass
 class Scene:
     speed: float
+    has_sidewalk: bool
     obstacles: List[Obstacle]
 
 
 def generate_scene(idx: int) -> None:
     random.seed()
+
     speed = random.uniform(5.0, 20.0)
+    has_sidewalk = random.choice([True, False])
+
+    # Base weights per obstacle category
+    cat_weights = {"vehicle": 1.0, "pedestrian": 1.2, "cone": 0.5}
+    categories = list(cat_weights.keys())
+
     num_obs = random.randint(1, 5)
     obstacles: List[Obstacle] = []
     for _ in range(num_obs):
         dist = random.uniform(0.0, 100.0)
         lat = random.uniform(-3.0, 3.0)
-        weight = 1.0 if dist <= speed * 7.0 else 0.0
-        obstacles.append(Obstacle(distance=dist, lateral=lat, weight=weight))
+        cat = random.choice(categories)
 
-    scene = Scene(speed=speed, obstacles=obstacles)
+        if dist <= speed * 7.0:
+            weight = cat_weights[cat]
+            if (
+                cat == "pedestrian"
+                and has_sidewalk
+                and abs(lat) > 2.0  # near sidewalk
+            ):
+                weight *= 2.0
+        else:
+            weight = 0.0
+
+        obstacles.append(
+            Obstacle(category=cat, distance=dist, lateral=lat, weight=weight)
+        )
+
+    scene = Scene(speed=speed, has_sidewalk=has_sidewalk, obstacles=obstacles)
 
     os.makedirs("data", exist_ok=True)
     with open(f"data/sample_{idx:03d}.json", "w", encoding="utf-8") as f:
         json.dump(asdict(scene), f, indent=2)
 
     fig, ax = plt.subplots(figsize=(6, 2))
-    ax.axhline(0.0, color="black", linewidth=1)
+    ax.axhline(0.0, color="black", linewidth=1, label="lane center")
+    if has_sidewalk:
+        ax.axhline(3.5, color="green", linestyle="--", linewidth=1, label="sidewalk")
+        ax.axhline(-3.5, color="green", linestyle="--", linewidth=1)
     ax.plot(0.0, 0.0, "bo", label="ego")
+
+    color_map = {"vehicle": "red", "pedestrian": "orange", "cone": "purple"}
     for obs in obstacles:
-        color = "red" if obs.weight > 0 else "gray"
+        color = color_map[obs.category] if obs.weight > 0 else "gray"
         ax.scatter(obs.distance, obs.lateral, c=color, s=80)
+
     ax.set_xlim(-5, 105)
     ax.set_ylim(-5, 5)
     ax.set_xlabel("Longitudinal [m]")
     ax.set_ylabel("Lateral [m]")
-    ax.set_title(f"Scene {idx} speed={speed:.1f} m/s")
+    title = f"Scene {idx} speed={speed:.1f} m/s"
+    if has_sidewalk:
+        title += " with sidewalk"
+    ax.set_title(title)
     ax.legend(loc="upper right")
     fig.tight_layout()
     fig.savefig(f"data/vis_{idx:03d}.png")


### PR DESCRIPTION
## Summary
- add obstacle categories and sidewalk flag to synthetic scene generator
- scale obstacle cost weights based on type and sidewalk proximity
- visualise sidewalks and obstacle classes in generated plots

## Testing
- `python scripts/generate_dataset.py --num 1 --workers 1`
- `cat data/sample_000.json`

------
https://chatgpt.com/codex/tasks/task_e_6894c52f03ec8321a3e283b13ab1fe78